### PR TITLE
build: remove specific version for mplcursors dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 install_requires =
 	PyQt5
 	matplotlib
-	mplcursors==0.5.1
+	mplcursors
 	xarray
 	netcdf4
 	pybladed @ git+https://github.com/DLR-AE/pybladed.git@parsing_campbell_data

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 install_requires =
 	PyQt5
 	matplotlib
-	mplcursors
+	mplcursors==0.5.2
 	xarray
 	netcdf4
 	pybladed @ git+https://github.com/DLR-AE/pybladed.git@parsing_campbell_data


### PR DESCRIPTION
A fresh installation of CampbellViewer will fail due to the specific version mplcursors==0.5.1 in the setup file. If we don't specify the version, the installation will succeed. 
Not quite sure if this version is a hard requirement. It seems to work with the newest version as well. 